### PR TITLE
Fixed population and poverty interchange

### DIFF
--- a/src/components/CommunityComparePage/CommunityCompareDetails.js
+++ b/src/components/CommunityComparePage/CommunityCompareDetails.js
@@ -322,13 +322,13 @@ const CommunityCompareDetails = () => {
                     </tr>
                     <tr>
                         <td>Above Poverty Line</td>
-                        <td>{community1 && nFormatter(community1[0].pop_change, 2)}%</td>
-                        <td>{community2 && nFormatter(community2[0].pop_change, 2)}%</td>
+                        <td>{community1 && nFormatter(community1[0].poverty, 2)}%</td>
+                        <td>{community2 && nFormatter(community2[0].poverty, 2)}%</td>
                     </tr>
                     <tr>
                         <td>Population Change (2010-2020)</td>
-                        <td>{community1 && nFormatter(community1[0].poverty, 2)}%</td>
-                        <td>{community2 && nFormatter(community2[0].poverty, 2)}%</td>
+                        <td>{community1 && nFormatter(community1[0].pop_change, 2)}%</td>
+                        <td>{community2 && nFormatter(community2[0].pop_change, 2)}%</td>
                     </tr>
                     <tr>
                         <td>Income Stability</td>

--- a/src/components/CommunityPage/CommunityDetails.js
+++ b/src/components/CommunityPage/CommunityDetails.js
@@ -342,11 +342,11 @@ const CommunityDetails = () => {
                 </tr>
                 <tr>
                     <td>Above Poverty Line</td>
-                    <td>{filteredData[0] && nFormatter(filteredData[0].pop_change, 2)}%</td>
+                    <td>{filteredData[0] && nFormatter(filteredData[0].poverty, 2)}%</td>
                 </tr>
                 <tr>
                     <td>Population Change (2010-2020)</td>
-                    <td>{filteredData[0] && nFormatter(filteredData[0].poverty, 2)}%</td>
+                    <td>{filteredData[0] && nFormatter(filteredData[0].pop_change, 2)}%</td>
                 </tr>
                 <tr>
                     <td>Income Stability</td>


### PR DESCRIPTION
This switches data for population and poverty back to their correct places in CommunityDetails.js and CommunityCompareDetails.js